### PR TITLE
Revert "Apply workaround for `vstest` fails on linux with .NET SDK 7.0.400"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,6 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-      # https://github.com/microsoft/vstest/issues/4549
-      - name: Workaround for .NET SDK 7.0.400 and vstest issue
-        run: dotnet new globaljson --sdk-version 6.0.413
       - name: Build
         run: |
           dotnet --info


### PR DESCRIPTION
This reverts commit 2552b4913ae8ffee05cc486c2108d8455123c684.