### PR TITLE
.NET 6 reach end of life since 2024-11-12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
       - name: Test
         run: |


### PR DESCRIPTION
- https://learn.microsoft.com/lifecycle/products/microsoft-net-and-net-core