### PR TITLE
chore: update dependencies + enable NuGet caching without lock files

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.5.9",
+      "version": "5.5.10",
       "commands": [
         "reportgenerator"
       ]

--- a/.gitignore
+++ b/.gitignore
@@ -234,6 +234,9 @@ PublishScripts/
 *.nuget.props
 *.nuget.targets
 
+# NuGet lock files (we use setup-dotnet cache + Directory.Packages.props instead of committing packages.lock.json)
+**/packages.lock.json
+
 # Microsoft Azure Build Output
 csx/
 *.build.csdef

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
-    <RestoreLockedMode Condition="'$(CI)' == 'true'">true</RestoreLockedMode>
+    <RestoreLockedMode Condition="'$(CI)' == 'true' AND Exists('$(MSBuildProjectDirectory)/packages.lock.json')">true</RestoreLockedMode>
     <!-- https://learn.microsoft.com/nuget/concepts/auditing-packages -->
     <NuGetAuditMode>all</NuGetAuditMode>
     <NuGetAuditLevel>moderate</NuGetAuditLevel>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,25 +5,25 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageVersion Include="System.Drawing.Common" Version="8.0.12" />
+    <PackageVersion Include="System.Drawing.Common" Version="8.0.27" />
   </ItemGroup>
 
   <ItemGroup
     Condition=" '$(TargetFramework)' != 'netstandard2.0' and '$(TargetFramework)' != 'net8.0' ">
-    <PackageVersion Include="System.Drawing.Common" Version="9.0.2" />
+    <PackageVersion Include="System.Drawing.Common" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="FluentNHibernate" Version="3.4.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="NHibernate" Version="5.5.2" />
+    <PackageVersion Include="NHibernate" Version="5.6.1" />
     <PackageVersion Include="System.Data.SQLite.Core" Version="1.0.119" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/src/NHibernate.Extensions.Logging/NHibernate.Extensions.Logging.csproj
+++ b/src/NHibernate.Extensions.Logging/NHibernate.Extensions.Logging.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <Description>Use Microsoft.Extensions.Logging as NHibernate logging provider</Description>
-    <Version>4.0.0</Version>
+    <Version>4.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NHibernate" VersionOverride="5.4.9" />
+    <PackageReference Include="NHibernate" VersionOverride="5.4.10" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">


### PR DESCRIPTION
### Summary
- Bump multiple NuGet packages (NHibernate 5.6.1, Microsoft.NET.Test.Sdk 18.6.0, coverlet.collector, System.Drawing.Common, etc.)
- Stop committing packages.lock.json files
- Use GitHub setup-dotnet built-in cache (keyed on Directory.Packages.props)
- Make RestoreLockedMode conditional so CI does not fail when no lock file is present
- Add **/packages.lock.json to .gitignore

This keeps local development fast (lock files still generated) while providing reliable NuGet caching in CI/CD.