### PR TITLE
chore(deps): upgrade System.Data.SQLite and target-specific dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,12 +9,12 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageVersion Include="System.Drawing.Common" Version="8.0.27" />
+    <PackageVersion Include="System.Drawing.Common" Version="8.0.28" />
   </ItemGroup>
 
   <ItemGroup
     Condition=" '$(TargetFramework)' != 'netstandard2.0' and '$(TargetFramework)' != 'net8.0' ">
-    <PackageVersion Include="System.Drawing.Common" Version="10.0.8" />
+    <PackageVersion Include="System.Drawing.Common" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>
@@ -24,7 +24,8 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NHibernate" Version="5.6.1" />
-    <PackageVersion Include="System.Data.SQLite.Core" Version="1.0.119" />
+    <PackageVersion Include="System.Data.SQLite" Version="2.0.3" />
+    <PackageVersion Include="SourceGear.sqlite3.ext" Version="3.50.4.5" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/samples/SampleApp/SampleApp.csproj
+++ b/samples/SampleApp/SampleApp.csproj
@@ -24,7 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SQLite.Core" />
+    <PackageReference Include="System.Data.SQLite" />
+    <PackageReference Include="SourceGear.sqlite3.ext" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/SampleWebApp/SampleWebApp.csproj
+++ b/samples/SampleWebApp/SampleWebApp.csproj
@@ -18,7 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SQLite.Core" />
+    <PackageReference Include="System.Data.SQLite" />
+    <PackageReference Include="SourceGear.sqlite3.ext" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR upgrades System.Data.SQLite to 2.0.3 and introduces SourceGear.sqlite3.ext 3.50.4.5 to resolve multiple security vulnerabilities (CVEs) present in the older embedded SQLite engine.

### Why this change is necessary:
* **Deprecation of 1.x**: The legacy `System.Data.SQLite.Core` (1.x series) is officially deprecated and no longer maintained.
* **Security Vulnerabilities**: Version 1.0.119 bundles SQLite 3.46.1, which is affected by CVE-2025-29087, CVE-2025-7709, CVE-2025-6965, and CVE-2025-3277.
* **Official Recommendation**: As documented on the [System.Data.SQLite Homepage](https://system.data.sqlite.org/), developers are advised to migrate to the 2.x releases.
* **New 2.x Architecture**: In 2.x, the native library (e.g. `SourceGear.sqlite3.ext`) is decoupled and must be referenced separately via NuGet.

### Upgrades:
* `System.Data.SQLite` from `System.Data.SQLite.Core` `1.0.119` to `2.0.3`.
* Added companion `SourceGear.sqlite3.ext` `3.50.4.5`.
* Upgraded `System.Drawing.Common` to `8.0.28` (for net8.0) and `10.0.9` (for others).